### PR TITLE
Update npm package dependencies and bootstrap CSS ref

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,10 @@
     "axios": "^0.15.3",
     "react": "^15.4.2",
     "react-bootstrap": "^0.30.7",
-    "react-dom": "^15.4.2",
+    "react-dom": "15.4.2",
     "react-router": "^3.0.2",
-    "react-scripts": "0.9.0"
+    "react-router-dom": "4.2.2",
+    "react-scripts": "2.1.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 		<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
The project as is currently builds but there are multiple package vulnerabilities and the version of bootstrap CSS that gets downloaded in index.html is incompatible with currently styling. This PR updates a few package versions to point where there are no vulnerabilities and pins the bootstrap CSS to 3.7.7 instead of latest which makes the styles (and therefore ability to display modal for adding posts) work again.